### PR TITLE
fix: don't re-initialize resolvers

### DIFF
--- a/server/src/main/kotlin/gg/airbrush/server/lib/MiniMessage.kt
+++ b/server/src/main/kotlin/gg/airbrush/server/lib/MiniMessage.kt
@@ -8,25 +8,24 @@ import net.kyori.adventure.text.minimessage.tag.Tag
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
 
-@Suppress("unused")
-fun String.mm(): Component {
-    val mm = MiniMessage.miniMessage()
-    return mm.deserialize(this, *getMMResolvers())
-        .decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE)
-}
+/** Global [MiniMessage] instance. */
+private val miniMessage = MiniMessage.builder()
+    .tags(TagResolver.resolver(
+        Placeholder.parsed("error", "<#ff6e6e>⚠ <#ff7f6e>"),
+        Placeholder.parsed("success", "<g>✔ "),
 
-private fun getMMResolvers(): Array<TagResolver> {
-    val errorResolver = Placeholder.parsed("error", "<#ff6e6e>⚠ <#ff7f6e>")
-    val successResolver = Placeholder.parsed("success", "<g>✔ ")
-
-    return listOf<TagResolver>(
-//        TagResolver.resolver("p", Tag.styling(TextColor.color(227, 176, 245))),
         TagResolver.resolver("p", Tag.styling(TextColor.color(200, 130, 224))),
-	    TagResolver.resolver("donator", Tag.styling(TextColor.color(255, 229, 99))),
+        TagResolver.resolver("donator", Tag.styling(TextColor.color(255, 229, 99))),
         TagResolver.resolver("s", Tag.styling(TextColor.color(244, 212, 255))),
         TagResolver.resolver("g", Tag.styling(TextColor.color(191, 255, 198))),
-        TagResolver.resolver("y", Tag.styling(TextColor.color(240, 245, 171))),
-        errorResolver,
-        successResolver
-    ).toTypedArray()
+        TagResolver.resolver("y", Tag.styling(TextColor.color(240, 245, 171)))
+    ))
+    .build()
+
+@Suppress("unused")
+fun String.mm(
+    vararg resolvers: TagResolver,
+): Component {
+    return miniMessage.deserialize(this, *resolvers)
+        .decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE)
 }


### PR DESCRIPTION
Prevents tag resolvers from being re-declared and allows for custom tag resolvers to be passed into the helper function.