### PR TITLE
Punishment system improvements

### DIFF
--- a/dev-env/docker-compose.yml
+++ b/dev-env/docker-compose.yml
@@ -17,8 +17,8 @@ services:
     depends_on:
       - mongo
     volumes:
-      - $PWD/plugins:/app/plugins
-      - $PWD/airbrush.jar:/app/airbrush.jar
+      - ./plugins:/app/plugins
+      - ./airbrush.jar:/app/airbrush.jar
 
 volumes:
   airbrush-mongo-data:

--- a/discord/src/main/kotlin/gg/airbrush/discord/data/DiscordConfig.kt
+++ b/discord/src/main/kotlin/gg/airbrush/discord/data/DiscordConfig.kt
@@ -14,7 +14,7 @@ package gg.airbrush.discord.data
 
 data class DiscordConfig(
     val botToken: String,
-    val channel: String,
+    val channels: Channels,
     val donor: String,
     val superdonor: String,
     val join: MessageContent,
@@ -26,4 +26,9 @@ data class DiscordConfig(
 
 data class MessageContent(
     val content: String
+)
+
+data class Channels(
+    val main: String,
+    val log: String
 )

--- a/discord/src/main/kotlin/gg/airbrush/discord/discordCommands/LinkCommand.kt
+++ b/discord/src/main/kotlin/gg/airbrush/discord/discordCommands/LinkCommand.kt
@@ -13,11 +13,11 @@
 package gg.airbrush.discord.discordCommands
 
 import gg.airbrush.discord.discordConfig
-import gg.airbrush.discord.lib.Placeholder
-import gg.airbrush.discord.lib.parsePlaceholders
 import gg.airbrush.sdk.SDK
 import gg.airbrush.sdk.classes.linking.Linking
+import gg.airbrush.sdk.lib.Placeholder
 import gg.airbrush.sdk.lib.PlayerUtils
+import gg.airbrush.sdk.lib.parsePlaceholders
 import gg.airbrush.server.lib.mm
 import me.santio.coffee.common.annotations.Command
 import me.santio.coffee.jda.annotations.Description

--- a/discord/src/main/kotlin/gg/airbrush/discord/events/HandleLink.kt
+++ b/discord/src/main/kotlin/gg/airbrush/discord/events/HandleLink.kt
@@ -31,7 +31,7 @@ object HandleLink {
 
 	private fun linkEvent(event: LinkAccountEvent) {
 		// Fetch the chat channel, this allows us to get the guild.
-		val channel = bot.getGuildChannelById(ChannelType.TEXT, discordConfig.channel.toLong()) ?: throw Exception("Failed to find guild!")
+		val channel = bot.getGuildChannelById(ChannelType.TEXT, discordConfig.channels.main.toLong()) ?: throw Exception("Failed to find guild!")
 
 		val paintersRole = channel.guild.roles.find {
 			it.name.lowercase() == "painters"

--- a/discord/src/main/kotlin/gg/airbrush/discord/events/PlayerChat.kt
+++ b/discord/src/main/kotlin/gg/airbrush/discord/events/PlayerChat.kt
@@ -17,9 +17,9 @@ package gg.airbrush.discord.events
 import gg.airbrush.discord.bot
 import gg.airbrush.discord.discordConfig
 import gg.airbrush.discord.eventNode
-import gg.airbrush.discord.lib.Placeholder
-import gg.airbrush.discord.lib.parsePlaceholders
 import gg.airbrush.sdk.SDK
+import gg.airbrush.sdk.lib.Placeholder
+import gg.airbrush.sdk.lib.parsePlaceholders
 import gg.airbrush.server.lib.mm
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter

--- a/discord/src/main/kotlin/gg/airbrush/discord/events/PlayerChat.kt
+++ b/discord/src/main/kotlin/gg/airbrush/discord/events/PlayerChat.kt
@@ -40,7 +40,7 @@ object PlayerChat : ListenerAdapter() {
 		if(event.isCancelled) return
 
 		val configMsg = discordConfig.chat.content
-		val channel = bot.getTextChannelById(discordConfig.channel.toLong())
+		val channel = bot.getTextChannelById(discordConfig.channels.main.toLong())
 			?: throw Exception("Failed to find guild!")
 
 		val rank = PlainTextComponentSerializer.plainText().serialize(
@@ -62,7 +62,7 @@ object PlayerChat : ListenerAdapter() {
 	}
 
 	override fun onMessageReceived(event: MessageReceivedEvent) {
-		if(event.channel.id != discordConfig.channel) return
+		if(event.channel.id != discordConfig.channels.main) return
 		if(event.author.isBot) return
 
 		val configMsg = discordConfig.ingame.content

--- a/discord/src/main/kotlin/gg/airbrush/discord/events/PlayerJoin.kt
+++ b/discord/src/main/kotlin/gg/airbrush/discord/events/PlayerJoin.kt
@@ -15,8 +15,8 @@ package gg.airbrush.discord.events
 import gg.airbrush.discord.bot
 import gg.airbrush.discord.discordConfig
 import gg.airbrush.discord.eventNode
-import gg.airbrush.discord.lib.Placeholder
-import gg.airbrush.discord.lib.parsePlaceholders
+import gg.airbrush.sdk.lib.Placeholder
+import gg.airbrush.sdk.lib.parsePlaceholders
 import net.minestom.server.entity.Player
 import net.minestom.server.event.player.PlayerDisconnectEvent
 import net.minestom.server.event.player.PlayerSpawnEvent

--- a/discord/src/main/kotlin/gg/airbrush/discord/events/PlayerJoin.kt
+++ b/discord/src/main/kotlin/gg/airbrush/discord/events/PlayerJoin.kt
@@ -50,7 +50,7 @@ object PlayerJoin {
 			)
 		)
 
-		val channel = bot.getTextChannelById(discordConfig.channel.toLong())
+		val channel = bot.getTextChannelById(discordConfig.channels.main.toLong())
 			?: throw Exception("Failed to find chat channel!")
 		channel.sendMessage(parsedMsg).queue()
 	}

--- a/discord/src/main/kotlin/gg/airbrush/discord/lib/Logging.kt
+++ b/discord/src/main/kotlin/gg/airbrush/discord/lib/Logging.kt
@@ -15,12 +15,11 @@
 package gg.airbrush.discord.lib
 
 import gg.airbrush.discord.bot
+import gg.airbrush.discord.discordConfig
 
 object Logging {
-	fun sendLog(msg: String) {
-		val channel = bot.getTextChannelById("1162903708108071037")
-			?: throw Exception("Failed to find logging channel!")
-
+	fun sendLog(msg: String, channelId: String = discordConfig.channels.log) {
+		val channel = bot.getTextChannelById(channelId) ?: throw Exception("Failed to find channel ($channelId)!")
 		return channel.sendMessage(msg).queue()
 	}
 }

--- a/discord/src/main/resources/config.toml
+++ b/discord/src/main/resources/config.toml
@@ -1,10 +1,12 @@
 botToken = "" # Discord bot token to be used for chat
-channel = "" # Channel for chat to be sent in
 
 donor = "" # Donor role ID
 superdonor = "" # Super donor role ID
-
 linkRequest = "<newline><#82a9ce>%username%<#bfdefb> requested to link their Discord<newline><#bffbdb><hover:show_text:'<#ffd4e3><i>Click to approve'><click:run_command:/link accept %sessionId%>✔ Accept </click><gray>| <#fbcebf><hover:show_text:'<#ffd4e3><i>Click to deny'><click:run_command:/link deny %sessionId%>✗ Deny</click><newline>"
+
+[channels]
+main = "" # Main chat channel ID
+log = "" # Log channel ID
 
 [join]
 content = "`[%timestamp%] %name% joined`"

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/Punishments.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/Punishments.kt
@@ -16,18 +16,11 @@ import cc.ekblad.toml.decode
 import cc.ekblad.toml.model.TomlException
 import cc.ekblad.toml.tomlMapper
 import gg.airbrush.core.lib.setInterval
-import gg.airbrush.punishments.commands.PunishCommand
-import gg.airbrush.punishments.commands.PunishmentsCommand
-import gg.airbrush.punishments.commands.RevertPunishmentCommand
+import gg.airbrush.punishments.commands.*
 import gg.airbrush.punishments.events.*
 import gg.airbrush.sdk.SDK
 import gg.airbrush.sdk.lib.ConfigUtils
-import gg.airbrush.sdk.lib.Placeholder
-import gg.airbrush.sdk.lib.Translations
-import gg.airbrush.sdk.lib.parsePlaceholders
-import gg.airbrush.server.lib.mm
 import gg.airbrush.server.plugins.Plugin
-import net.kyori.adventure.text.Component
 import net.minestom.server.MinecraftServer
 import net.minestom.server.event.EventNode
 import java.time.Instant
@@ -37,22 +30,7 @@ data class Punishment(
 	val longReason: String = shortReason,
 	val action: String,
 	val duration: String?
-) {
-	fun getDisconnectMessage(): Component {
-		val translation = Translations.getString("punishments.playerBanned")
-		val title = Translations.getString("core.scoreboard.title")
-
-		// Nullable due to custom punishments
-		val reason = this.longReason
-
-		val placeholders = listOf(
-			Placeholder("%title%", title),
-			Placeholder("%long_reason%", reason),
-		)
-
-		return translation.parsePlaceholders(placeholders).trimIndent().mm()
-	}
-}
+)
 
 data class PunishmentsConfig(
 	val punishments: Map<String, Punishment>
@@ -86,6 +64,9 @@ class Punishments : Plugin() {
 	    manager.register(PunishCommand())
 	    manager.register(PunishmentsCommand())
 	    manager.register(RevertPunishmentCommand())
+		manager.register(BanCommand())
+		manager.register(KickCommand())
+		manager.register(MuteCommand())
 
 		MinecraftServer.getGlobalEventHandler().addChild(eventNode)
 	    PlayerEvents()

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/Punishments.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/Punishments.kt
@@ -22,7 +22,12 @@ import gg.airbrush.punishments.commands.RevertPunishmentCommand
 import gg.airbrush.punishments.events.*
 import gg.airbrush.sdk.SDK
 import gg.airbrush.sdk.lib.ConfigUtils
+import gg.airbrush.sdk.lib.Placeholder
+import gg.airbrush.sdk.lib.Translations
+import gg.airbrush.sdk.lib.parsePlaceholders
+import gg.airbrush.server.lib.mm
 import gg.airbrush.server.plugins.Plugin
+import net.kyori.adventure.text.Component
 import net.minestom.server.MinecraftServer
 import net.minestom.server.event.EventNode
 import java.time.Instant
@@ -32,7 +37,22 @@ data class Punishment(
 	val longReason: String = shortReason,
 	val action: String,
 	val duration: String?
-)
+) {
+	fun getDisconnectMessage(): Component {
+		val translation = Translations.getString("punishments.playerBanned")
+		val title = Translations.getString("core.scoreboard.title")
+
+		// Nullable due to custom punishments
+		val reason = this.longReason
+
+		val placeholders = listOf(
+			Placeholder("%title%", title),
+			Placeholder("%long_reason%", reason),
+		)
+
+		return translation.parsePlaceholders(placeholders).trimIndent().mm()
+	}
+}
 
 data class PunishmentsConfig(
 	val punishments: Map<String, Punishment>

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/Punishments.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/Punishments.kt
@@ -67,6 +67,7 @@ class Punishments : Plugin() {
 		manager.register(BanCommand())
 		manager.register(KickCommand())
 		manager.register(MuteCommand())
+		manager.register(PunishmentCommand())
 
 		MinecraftServer.getGlobalEventHandler().addChild(eventNode)
 	    PlayerEvents()

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/Punishments.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/Punishments.kt
@@ -28,22 +28,14 @@ import net.minestom.server.event.EventNode
 import java.time.Instant
 
 data class Punishment(
-	val reason: String,
+	val shortReason: String,
+	val longReason: String = shortReason,
 	val action: String,
 	val duration: String?
 )
 
 data class PunishmentsConfig(
-	val hate: Punishment,
-	val flood: Punishment,
-	val filter: Punishment,
-	val nsfw: Punishment,
-	val ad: Punishment,
-	val grief: Punishment,
-	val arguing: Punishment,
-	val dox: Punishment,
-	val death: Punishment,
-	val under13: Punishment
+	val punishments: Map<String, Punishment>
 )
 
 lateinit var punishmentConfig: PunishmentsConfig

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/BanCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/BanCommand.kt
@@ -52,7 +52,7 @@ class BanCommand : Command("ban") {
         val duration = context.get<String?>("duration") ?: "FOREVER"
 
         val punishable = canPunish(offlinePlayer.uniqueId)
-        if(punishable) {
+        if(!punishable) {
             sender.sendMessage("<error>You cannot punish this person!".mm())
             return@runBlocking
         }

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/BanCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/BanCommand.kt
@@ -52,10 +52,10 @@ class BanCommand : Command("ban") {
         val duration = context.get<String?>("duration") ?: "FOREVER"
 
         val punishable = canPunish(offlinePlayer.uniqueId)
-        /*		if(punishable) {
-                    sender.sendMessage("<error>You cannot punish this person!".mm())
-                    return@runBlocking
-                }*/
+        if(punishable) {
+            sender.sendMessage("<error>You cannot punish this person!".mm())
+            return@runBlocking
+        }
 
         val activePunishment = SDK.punishments.list(offlinePlayer.uniqueId).find {it.data.active}
         if(activePunishment !== null) {

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/BanCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/BanCommand.kt
@@ -29,8 +29,7 @@ import net.minestom.server.command.builder.arguments.ArgumentType
 import net.minestom.server.entity.Player
 
 class BanCommand : Command("ban") {
-    private val notesArg = ArgumentType.StringArray("notes")
-    private val reasonArg = ArgumentType.String("reason")
+    private val reasonArg = ArgumentType.StringArray("reason")
     private val durationArg = ArgumentType.String("duration")
 
     init {
@@ -42,17 +41,14 @@ class BanCommand : Command("ban") {
             sender.sendMessage("<error>/ban <player> [reason] [duration] [notes...]".mm())
         }
 
-        addSyntax(this::apply, reasonArg, durationArg, notesArg)
-        addSyntax(this::apply, reasonArg, notesArg)
-        addSyntax(this::apply, reasonArg, durationArg)
+        addSyntax(this::apply, durationArg, reasonArg)
         addSyntax(this::apply, reasonArg)
         addSyntax(this::apply)
     }
 
     private fun apply(sender: CommandSender, context: CommandContext) = runBlocking {
         val offlinePlayer = context.get<Deferred<OfflinePlayer>>("offline-player").await()
-        val notes = context.get(notesArg)
-        val reason = context.get<String?>("reason") ?: "No reason specified"
+        val reason = context.get(reasonArg)
         val duration = context.get<String?>("duration") ?: "FOREVER"
 
         val punishable = canPunish(offlinePlayer.uniqueId)
@@ -67,15 +63,13 @@ class BanCommand : Command("ban") {
             return@runBlocking
         }
 
-        val punishmentNotes = if(notes !== null) notes.joinToString(" ") { it } else ""
-
         Punishment(
             moderator =  if(sender is Player) User(sender.uuid, sender.username) else User(nilUUID, "Console"),
             player = User(offlinePlayer.uniqueId, offlinePlayer.username),
-            reason = reason,
+            reason = reason.joinToString(" "),
             type = PunishmentTypes.BAN,
             duration = duration,
-            notes = punishmentNotes
+            notes = ""
         ).handle()
     }
 

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/BanCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/BanCommand.kt
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Airbrush
+ *
+ * Copyright (c) Airbrush Team
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package gg.airbrush.punishments.commands
+
+import gg.airbrush.punishments.arguments.OfflinePlayerArgument
+import gg.airbrush.punishments.enums.PunishmentTypes
+import gg.airbrush.punishments.lib.*
+import gg.airbrush.sdk.SDK
+import gg.airbrush.server.lib.mm
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.runBlocking
+import net.minestom.server.command.CommandSender
+import net.minestom.server.command.builder.Command
+import net.minestom.server.command.builder.CommandContext
+import net.minestom.server.command.builder.CommandExecutor
+import net.minestom.server.command.builder.CommandSyntax
+import net.minestom.server.command.builder.arguments.Argument
+import net.minestom.server.command.builder.arguments.ArgumentType
+import net.minestom.server.entity.Player
+
+class BanCommand : Command("ban") {
+    private val notesArg = ArgumentType.StringArray("notes")
+    private val reasonArg = ArgumentType.String("reason")
+    private val durationArg = ArgumentType.String("duration")
+
+    init {
+        setCondition { sender, _ ->
+            sender.hasPermission("punishments.ban")
+        }
+
+        defaultExecutor = CommandExecutor { sender, _ ->
+            sender.sendMessage("<error>/ban <player> [reason] [duration] [notes...]".mm())
+        }
+
+        addSyntax(this::apply, reasonArg, durationArg, notesArg)
+        addSyntax(this::apply, reasonArg, notesArg)
+        addSyntax(this::apply, reasonArg, durationArg)
+        addSyntax(this::apply, reasonArg)
+        addSyntax(this::apply)
+    }
+
+    private fun apply(sender: CommandSender, context: CommandContext) = runBlocking {
+        val offlinePlayer = context.get<Deferred<OfflinePlayer>>("offline-player").await()
+        val notes = context.get(notesArg)
+        val reason = context.get<String?>("reason") ?: "No reason specified"
+        val duration = context.get<String?>("duration") ?: "FOREVER"
+
+        val punishable = canPunish(offlinePlayer.uniqueId)
+        /*		if(punishable) {
+                    sender.sendMessage("<error>You cannot punish this person!".mm())
+                    return@runBlocking
+                }*/
+
+        val activePunishment = SDK.punishments.list(offlinePlayer.uniqueId).find {it.data.active}
+        if(activePunishment !== null) {
+            sender.sendMessage("<error>This player already has an active punishment!".mm())
+            return@runBlocking
+        }
+
+        val punishmentNotes = if(notes !== null) notes.joinToString(" ") { it } else ""
+
+        Punishment(
+            moderator =  if(sender is Player) User(sender.uuid, sender.username) else User(nilUUID, "Console"),
+            player = User(offlinePlayer.uniqueId, offlinePlayer.username),
+            reason = reason,
+            type = PunishmentTypes.BAN,
+            duration = duration,
+            notes = punishmentNotes
+        ).handle()
+    }
+
+    override fun addSyntax(
+        executor: CommandExecutor,
+        vararg args: Argument<*>
+    ): MutableCollection<CommandSyntax> {
+        return super.addSyntax(executor, OfflinePlayerArgument("offline-player"), *args)
+    }
+}

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/BanCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/BanCommand.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of Airbrush
  *
- * Copyright (c) Airbrush Team
+ * Copyright (c) 2024 Airbrush Team
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/KickCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/KickCommand.kt
@@ -48,11 +48,10 @@ class KickCommand : Command("kick") {
         val reason = context.get(reasonArg)
 
         val punishable = canPunish(offlinePlayer.uniqueId)
-        /*		if(punishable) {
-                    sender.sendMessage("<error>You cannot punish this person!".mm())
-                    return@runBlocking
-                }*/
-
+        if(punishable) {
+            sender.sendMessage("<error>You cannot punish this person!".mm())
+            return@runBlocking
+        }
 
         Punishment(
             moderator = if(sender is Player) User(sender.uuid, sender.username) else User(nilUUID, "Console"),

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/KickCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/KickCommand.kt
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Airbrush
+ *
+ * Copyright (c) Airbrush Team
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package gg.airbrush.punishments.commands
+
+import gg.airbrush.punishments.arguments.OfflinePlayerArgument
+import gg.airbrush.punishments.enums.PunishmentTypes
+import gg.airbrush.punishments.lib.*
+import gg.airbrush.server.lib.mm
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.runBlocking
+import net.minestom.server.command.CommandSender
+import net.minestom.server.command.builder.Command
+import net.minestom.server.command.builder.CommandContext
+import net.minestom.server.command.builder.CommandExecutor
+import net.minestom.server.command.builder.CommandSyntax
+import net.minestom.server.command.builder.arguments.Argument
+import net.minestom.server.command.builder.arguments.ArgumentType
+import net.minestom.server.entity.Player
+
+class KickCommand : Command("kick") {
+    private val notesArg = ArgumentType.StringArray("notes")
+    private val reasonArg = ArgumentType.String("reason")
+
+    init {
+        setCondition { sender, _ ->
+            sender.hasPermission("punishments.kick")
+        }
+
+        defaultExecutor = CommandExecutor { sender, _ ->
+            sender.sendMessage("<error>/kick <player> [reason] [notes...]".mm())
+        }
+
+        addSyntax(this::apply, reasonArg, notesArg)
+        addSyntax(this::apply, reasonArg)
+        addSyntax(this::apply)
+    }
+
+    private fun apply(sender: CommandSender, context: CommandContext) = runBlocking {
+        val offlinePlayer = context.get<Deferred<OfflinePlayer>>("offline-player").await()
+        val notes = context.get(notesArg)
+        val reason = context.get<String?>("reason") ?: "No reason specified"
+
+        val punishable = canPunish(offlinePlayer.uniqueId)
+        /*		if(punishable) {
+                    sender.sendMessage("<error>You cannot punish this person!".mm())
+                    return@runBlocking
+                }*/
+
+        val punishmentNotes = if(notes !== null) notes.joinToString(" ") { it } else ""
+
+        Punishment(
+            moderator =  if(sender is Player) User(sender.uuid, sender.username) else User(nilUUID, "Console"),
+            player = User(offlinePlayer.uniqueId, offlinePlayer.username),
+            reason = reason,
+            type = PunishmentTypes.KICK,
+            notes = punishmentNotes
+        ).handle()
+    }
+
+    override fun addSyntax(
+        executor: CommandExecutor,
+        vararg args: Argument<*>
+    ): MutableCollection<CommandSyntax> {
+        return super.addSyntax(executor, OfflinePlayerArgument("offline-player"), *args)
+    }
+}

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/KickCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/KickCommand.kt
@@ -48,7 +48,7 @@ class KickCommand : Command("kick") {
         val reason = context.get(reasonArg)
 
         val punishable = canPunish(offlinePlayer.uniqueId)
-        if(punishable) {
+        if(!punishable) {
             sender.sendMessage("<error>You cannot punish this person!".mm())
             return@runBlocking
         }

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/KickCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/KickCommand.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of Airbrush
  *
- * Copyright (c) Airbrush Team
+ * Copyright (c) 2024 Airbrush Team
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/KickCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/KickCommand.kt
@@ -28,8 +28,7 @@ import net.minestom.server.command.builder.arguments.ArgumentType
 import net.minestom.server.entity.Player
 
 class KickCommand : Command("kick") {
-    private val notesArg = ArgumentType.StringArray("notes")
-    private val reasonArg = ArgumentType.String("reason")
+    private val reasonArg = ArgumentType.StringArray("reason")
 
     init {
         setCondition { sender, _ ->
@@ -40,15 +39,13 @@ class KickCommand : Command("kick") {
             sender.sendMessage("<error>/kick <player> [reason] [notes...]".mm())
         }
 
-        addSyntax(this::apply, reasonArg, notesArg)
         addSyntax(this::apply, reasonArg)
         addSyntax(this::apply)
     }
 
     private fun apply(sender: CommandSender, context: CommandContext) = runBlocking {
         val offlinePlayer = context.get<Deferred<OfflinePlayer>>("offline-player").await()
-        val notes = context.get(notesArg)
-        val reason = context.get<String?>("reason") ?: "No reason specified"
+        val reason = context.get(reasonArg)
 
         val punishable = canPunish(offlinePlayer.uniqueId)
         /*		if(punishable) {
@@ -56,14 +53,13 @@ class KickCommand : Command("kick") {
                     return@runBlocking
                 }*/
 
-        val punishmentNotes = if(notes !== null) notes.joinToString(" ") { it } else ""
 
         Punishment(
-            moderator =  if(sender is Player) User(sender.uuid, sender.username) else User(nilUUID, "Console"),
+            moderator = if(sender is Player) User(sender.uuid, sender.username) else User(nilUUID, "Console"),
             player = User(offlinePlayer.uniqueId, offlinePlayer.username),
-            reason = reason,
+            reason = reason.joinToString(" "),
             type = PunishmentTypes.KICK,
-            notes = punishmentNotes
+            notes = ""
         ).handle()
     }
 

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/MuteCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/MuteCommand.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of Airbrush
  *
- * Copyright (c) Airbrush Team
+ * Copyright (c) 2024 Airbrush Team
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/MuteCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/MuteCommand.kt
@@ -52,7 +52,7 @@ class MuteCommand : Command("mute") {
         val duration = context.get<String?>("duration") ?: "FOREVER"
 
         val punishable = canPunish(offlinePlayer.uniqueId)
-        if(punishable) {
+        if(!punishable) {
             sender.sendMessage("<error>You cannot punish this person!".mm())
             return@runBlocking
         }

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/MuteCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/MuteCommand.kt
@@ -29,8 +29,7 @@ import net.minestom.server.command.builder.arguments.ArgumentType
 import net.minestom.server.entity.Player
 
 class MuteCommand : Command("mute") {
-    private val notesArg = ArgumentType.StringArray("notes")
-    private val reasonArg = ArgumentType.String("reason")
+    private val reasonArg = ArgumentType.StringArray("reason")
     private val durationArg = ArgumentType.String("duration")
 
     init {
@@ -42,8 +41,6 @@ class MuteCommand : Command("mute") {
             sender.sendMessage("<error>/mute <player> [reason] [duration] [notes...]".mm())
         }
 
-        addSyntax(this::apply, reasonArg, durationArg, notesArg)
-        addSyntax(this::apply, reasonArg, notesArg)
         addSyntax(this::apply, reasonArg, durationArg)
         addSyntax(this::apply, reasonArg)
         addSyntax(this::apply)
@@ -51,8 +48,7 @@ class MuteCommand : Command("mute") {
 
     private fun apply(sender: CommandSender, context: CommandContext) = runBlocking {
         val offlinePlayer = context.get<Deferred<OfflinePlayer>>("offline-player").await()
-        val notes = context.get(notesArg)
-        val reason = context.get<String?>("reason") ?: "No reason specified"
+        val reason = context.get(reasonArg)
         val duration = context.get<String?>("duration") ?: "FOREVER"
 
         val punishable = canPunish(offlinePlayer.uniqueId)
@@ -67,15 +63,13 @@ class MuteCommand : Command("mute") {
             return@runBlocking
         }
 
-        val punishmentNotes = if(notes !== null) notes.joinToString(" ") { it } else ""
-
         Punishment(
-            moderator =  if(sender is Player) User(sender.uuid, sender.username) else User(nilUUID, "Console"),
+            moderator = if(sender is Player) User(sender.uuid, sender.username) else User(nilUUID, "Console"),
             player = User(offlinePlayer.uniqueId, offlinePlayer.username),
-            reason = reason,
+            reason = reason.joinToString(" "),
             type = PunishmentTypes.MUTE,
             duration = duration,
-            notes = punishmentNotes
+            notes = ""
         ).handle()
     }
 

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/MuteCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/MuteCommand.kt
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Airbrush
+ *
+ * Copyright (c) Airbrush Team
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package gg.airbrush.punishments.commands
+
+import gg.airbrush.punishments.arguments.OfflinePlayerArgument
+import gg.airbrush.punishments.enums.PunishmentTypes
+import gg.airbrush.punishments.lib.*
+import gg.airbrush.sdk.SDK
+import gg.airbrush.server.lib.mm
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.runBlocking
+import net.minestom.server.command.CommandSender
+import net.minestom.server.command.builder.Command
+import net.minestom.server.command.builder.CommandContext
+import net.minestom.server.command.builder.CommandExecutor
+import net.minestom.server.command.builder.CommandSyntax
+import net.minestom.server.command.builder.arguments.Argument
+import net.minestom.server.command.builder.arguments.ArgumentType
+import net.minestom.server.entity.Player
+
+class MuteCommand : Command("mute") {
+    private val notesArg = ArgumentType.StringArray("notes")
+    private val reasonArg = ArgumentType.String("reason")
+    private val durationArg = ArgumentType.String("duration")
+
+    init {
+        setCondition { sender, _ ->
+            sender.hasPermission("punishments.mute")
+        }
+
+        defaultExecutor = CommandExecutor { sender, _ ->
+            sender.sendMessage("<error>/mute <player> [reason] [duration] [notes...]".mm())
+        }
+
+        addSyntax(this::apply, reasonArg, durationArg, notesArg)
+        addSyntax(this::apply, reasonArg, notesArg)
+        addSyntax(this::apply, reasonArg, durationArg)
+        addSyntax(this::apply, reasonArg)
+        addSyntax(this::apply)
+    }
+
+    private fun apply(sender: CommandSender, context: CommandContext) = runBlocking {
+        val offlinePlayer = context.get<Deferred<OfflinePlayer>>("offline-player").await()
+        val notes = context.get(notesArg)
+        val reason = context.get<String?>("reason") ?: "No reason specified"
+        val duration = context.get<String?>("duration") ?: "FOREVER"
+
+        val punishable = canPunish(offlinePlayer.uniqueId)
+        /*		if(punishable) {
+                    sender.sendMessage("<error>You cannot punish this person!".mm())
+                    return@runBlocking
+                }*/
+
+        val activePunishment = SDK.punishments.list(offlinePlayer.uniqueId).find {it.data.active}
+        if(activePunishment !== null) {
+            sender.sendMessage("<error>This player already has an active punishment!".mm())
+            return@runBlocking
+        }
+
+        val punishmentNotes = if(notes !== null) notes.joinToString(" ") { it } else ""
+
+        Punishment(
+            moderator =  if(sender is Player) User(sender.uuid, sender.username) else User(nilUUID, "Console"),
+            player = User(offlinePlayer.uniqueId, offlinePlayer.username),
+            reason = reason,
+            type = PunishmentTypes.MUTE,
+            duration = duration,
+            notes = punishmentNotes
+        ).handle()
+    }
+
+    override fun addSyntax(
+        executor: CommandExecutor,
+        vararg args: Argument<*>
+    ): MutableCollection<CommandSyntax> {
+        return super.addSyntax(executor, OfflinePlayerArgument("offline-player"), *args)
+    }
+}

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/MuteCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/MuteCommand.kt
@@ -52,10 +52,10 @@ class MuteCommand : Command("mute") {
         val duration = context.get<String?>("duration") ?: "FOREVER"
 
         val punishable = canPunish(offlinePlayer.uniqueId)
-        /*		if(punishable) {
-                    sender.sendMessage("<error>You cannot punish this person!".mm())
-                    return@runBlocking
-                }*/
+        if(punishable) {
+            sender.sendMessage("<error>You cannot punish this person!".mm())
+            return@runBlocking
+        }
 
         val activePunishment = SDK.punishments.list(offlinePlayer.uniqueId).find {it.data.active}
         if(activePunishment !== null) {

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/PunishCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/PunishCommand.kt
@@ -69,7 +69,6 @@ fun String.toPluralForm(): String {
 	}
 }
 
-
 class PunishCommand : Command("punish") {
 	private val notesArg = ArgumentType.StringArray("notes")
 	private val typeArg = ArgumentType.String("type").setSuggestionCallback { _, context, suggestions ->
@@ -128,7 +127,7 @@ class PunishCommand : Command("punish") {
 		val punishment = SDK.punishments.create(
 			moderator = moderator,
 			player = offlinePlayer.uniqueId,
-			reason = punishmentInfo.longReason,
+			reason = punishmentShort.uppercase(),
 			type = punishmentType.ordinal,
 			// TODO: Make duration non-null in the SDK.
 			duration = if(punishmentInfo.duration !== null)
@@ -196,7 +195,7 @@ class PunishCommand : Command("punish") {
 		when(punishmentType) {
 			PunishmentTypes.BAN,
 			PunishmentTypes.KICK -> {
-				player.kick(punishmentInfo.longReason)
+				player.kick(punishmentInfo.getDisconnectMessage())
 			}
 			PunishmentTypes.MUTE -> {
 				val mutedMsg = Translations.getString("punishments.playerMuted").parsePlaceholders(logPlaceholders).trimIndent()

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/PunishCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/PunishCommand.kt
@@ -89,10 +89,10 @@ class PunishCommand : Command("punish") {
 		addSyntax(this::apply, typeArg)
 	}
 
-	private fun canPunish(player: OfflinePlayer): Boolean {
-		val playerExists = SDK.players.exists(player.uniqueId)
+	private fun canPunish(uuid: UUID): Boolean {
+		val playerExists = SDK.players.exists(uuid)
 		if(!playerExists) return true
-		val offenderRank = SDK.players.get(player.uniqueId).getRank()
+		val offenderRank = SDK.players.get(uuid).getRank()
 		return offenderRank.getData().permissions.find { it.key == "core.staff" } !== null
 	}
 
@@ -102,7 +102,7 @@ class PunishCommand : Command("punish") {
 		val offlinePlayer = context.get<Deferred<OfflinePlayer>>("offline-player").await()
 		val notes = context.get(notesArg)
 
-		val punishable = canPunish(offlinePlayer)
+		val punishable = canPunish(offlinePlayer.uniqueId)
 /*		if(punishable) {
 			sender.sendMessage("<error>You cannot punish this person!".mm())
 			return@runBlocking
@@ -154,7 +154,7 @@ class PunishCommand : Command("punish") {
 			}
 			if(numericValue > 1) unit += "s"
 
-			duration = "$numericValue ${unit.uppercase()}"
+			duration = "$numericValue $unit"
 		}
 
 		val logPlaceholders = listOf(
@@ -198,7 +198,10 @@ class PunishCommand : Command("punish") {
 			PunishmentTypes.KICK -> {
 				player.kick(punishmentInfo.longReason)
 			}
-			else -> return@runBlocking
+			PunishmentTypes.MUTE -> {
+				val mutedMsg = Translations.getString("punishments.playerMuted").parsePlaceholders(logPlaceholders).trimIndent()
+				player.sendMessage(mutedMsg.mm())
+			}
 		}
 	}
 

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/PunishCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/PunishCommand.kt
@@ -33,14 +33,6 @@ import java.util.*
 
 var nilUUID = UUID(0, 0)
 
-fun String.toPluralForm(): String {
-	return when {
-		endsWith("n") -> this + "ned"
-		endsWith("e") -> this + "d"
-		else -> this + "ed"
-	}
-}
-
 class PunishCommand : Command("punish") {
 	private val notesArg = ArgumentType.StringArray("notes")
 	private val typeArg = ArgumentType.String("type").setSuggestionCallback { _, context, suggestions ->
@@ -58,13 +50,6 @@ class PunishCommand : Command("punish") {
 
 		addSyntax(this::apply, typeArg, notesArg)
 		addSyntax(this::apply, typeArg)
-	}
-
-	private fun canPunish(uuid: UUID): Boolean {
-		val playerExists = SDK.players.exists(uuid)
-		if(!playerExists) return true
-		val offenderRank = SDK.players.get(uuid).getRank()
-		return offenderRank.getData().permissions.find { it.key == "core.staff" } !== null
 	}
 
 	private fun apply(sender: CommandSender, context: CommandContext) = runBlocking {
@@ -94,7 +79,7 @@ class PunishCommand : Command("punish") {
 		val punishmentType = PunishmentTypes.valueOf(punishmentInfo.action.uppercase())
 		val punishmentNotes = if(notes !== null) notes.joinToString(" ") { it } else ""
 
-		 PunishmentHandler(
+		Punishment(
 			moderator =  if(sender is Player) User(sender.uuid, sender.username) else User(nilUUID, "Console"),
 			player = User(offlinePlayer.uniqueId, offlinePlayer.username),
 			reason = punishmentShort.uppercase(),

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/PunishmentCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/PunishmentCommand.kt
@@ -83,7 +83,8 @@ class PunishmentCommand : Command("punishment") {
             Placeholder("%type%", punishmentType.name),
             Placeholder("%issued_at%", issuedAt),
             Placeholder("%expires_at%", expiresAt),
-            Placeholder("%status%", status)
+            Placeholder("%status%", status),
+            Placeholder("%id%", punishment.data.id)
         )
 
         val overviewPage = Translations.getString("punishments.view.overview")

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/PunishmentCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/PunishmentCommand.kt
@@ -70,7 +70,7 @@ class PunishmentCommand : Command("punishment") {
         val reasonText = punishment.getReasonString()
 
         val issuedAt = formatDate(punishment.getCreatedAt())
-        val expiresAt = punishment.getExpiry()
+        val expiresAt = formatDate(punishment.getExpiry())
 
         var status = "active"
         if(!punishment.data.active) status = "expired"
@@ -82,7 +82,7 @@ class PunishmentCommand : Command("punishment") {
             Placeholder("%reason%", reasonText),
             Placeholder("%type%", punishmentType.name),
             Placeholder("%issued_at%", issuedAt),
-            Placeholder("%expires_at%", formatDate(expiresAt)),
+            Placeholder("%expires_at%", expiresAt),
             Placeholder("%status%", status)
         )
 

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/PunishmentCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/PunishmentCommand.kt
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Airbrush
+ *
+ * Copyright (c) 2024 Airbrush Team
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package gg.airbrush.punishments.commands
+
+import gg.airbrush.punishments.enums.PunishmentTypes
+import gg.airbrush.sdk.SDK
+import gg.airbrush.sdk.lib.*
+import gg.airbrush.server.lib.mm
+import kotlinx.coroutines.runBlocking
+import net.kyori.adventure.inventory.Book
+import net.kyori.adventure.text.Component
+import net.minestom.server.command.CommandSender
+import net.minestom.server.command.builder.Command
+import net.minestom.server.command.builder.CommandContext
+import net.minestom.server.command.builder.CommandExecutor
+import net.minestom.server.command.builder.arguments.ArgumentType
+import java.util.UUID
+
+class PunishmentCommand : Command("punishment") {
+    private val idArg = ArgumentType.String("id")
+    init {
+        setCondition { sender, _ ->
+            sender.hasPermission("core.staff")
+        }
+
+        defaultExecutor = CommandExecutor { sender, _ ->
+            sender.sendMessage("<error>Invalid usage.".mm())
+        }
+
+        addSyntax(this::apply, idArg)
+    }
+
+    private fun apply(sender: CommandSender, context: CommandContext) = runBlocking {
+        val punishmentId = UUID.fromString(context.get("id"))
+
+        if(!SDK.punishments.exists(punishmentId)) {
+            sender.sendMessage("<error>Invalid punishment ID.".mm())
+            return@runBlocking
+        }
+
+        val punishment = SDK.punishments.get(punishmentId)
+
+        val pages = mutableListOf<Component>()
+        val book = Book.builder().author(Component.empty()).title(Component.empty())
+
+        val playerName = PlayerUtils.getName(punishment.getPlayer())
+        val moderatorName = PlayerUtils.getName(punishment.getModerator())
+        val punishmentType = PunishmentTypes.entries[punishment.data.type]
+
+        val placeholders = listOf(
+            Placeholder("%player%", playerName),
+            Placeholder("%moderator%", moderatorName),
+            Placeholder("%reason%", punishment.data.reason),
+            Placeholder("%type%", punishmentType.name)
+        )
+
+        val translation = Translations.getString("punishments.view.overview").parsePlaceholders(placeholders)
+        val page = translation.trimIndent().replaceTabs()
+
+        println(page)
+
+        pages.add(page.mm())
+
+        sender.openBook(book.pages(pages))
+    }
+}

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/PunishmentCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/PunishmentCommand.kt
@@ -86,7 +86,7 @@ class PunishmentCommand : Command("punishment") {
             Placeholder("%status%", status)
         )
 
-        val overviewPage = Translations.getString("punishments.view.overview").parsePlaceholders(placeholders)
+        val overviewPage = Translations.getString("punishments.view.overview")
             .parsePlaceholders(placeholders)
             .trimIndent()
             .replaceTabs()

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/PunishmentCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/PunishmentCommand.kt
@@ -86,10 +86,31 @@ class PunishmentCommand : Command("punishment") {
             Placeholder("%status%", status)
         )
 
-        val translation = Translations.getString("punishments.view.overview").parsePlaceholders(placeholders)
-        val page = translation.trimIndent().replaceTabs()
+        val overviewPage = Translations.getString("punishments.view.overview").parsePlaceholders(placeholders)
+            .parsePlaceholders(placeholders)
+            .trimIndent()
+            .replaceTabs()
+        pages.add(overviewPage.mm())
 
-        pages.add(page.mm())
+        val notes = punishment.data.notes
+        if(!notes.isNullOrEmpty()) {
+            val notesPage = Translations.getString("punishments.view.notes")
+                .parsePlaceholders(placeholders.plus(Placeholder("%notes%", notes)))
+                .trimIndent()
+                .replaceTabs()
+            pages.add(notesPage.mm())
+        }
+
+        val reverted = punishment.data.reverted
+        if(reverted !== null) {
+            val revertedBy = PlayerUtils.getName(UUID.fromString(reverted.revertedBy))
+            val revertedPage = Translations.getString("punishments.view.reverted")
+                .parsePlaceholders(placeholders.plus(Placeholder("%reverted_by%", revertedBy)))
+                .parsePlaceholders(placeholders.plus(Placeholder("%reverted_reason%", reverted.revertedReason)))
+                .trimIndent()
+                .replaceTabs()
+            pages.add(revertedPage.mm())
+        }
 
         sender.openBook(book.pages(pages))
     }

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/PunishmentsCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/PunishmentsCommand.kt
@@ -79,7 +79,11 @@ class PunishmentsCommand : Command("punishments") {
 			return@runBlocking
 		}
 
-		val punishments = playerPunishments.joinToString("\n") {
+		val allPunishments = playerPunishments
+			.sortedWith(compareByDescending<AirbrushPunishment> { it.data.active }
+			.thenBy { it.data.type == PunishmentTypes.BAN.ordinal })
+
+		val punishments = allPunishments.joinToString("\n") {
 			val type = PunishmentTypes.entries[it.data.type]
 			val text = it.getReasonString()
 			"<hover:show_text:'<p>View ${type.name.lowercase()} information</p>'><click:run_command:/punishment ${it.data.id}>$text</click></hover>"

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/RevertPunishmentCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/RevertPunishmentCommand.kt
@@ -16,6 +16,7 @@ import gg.airbrush.discord.bot
 import gg.airbrush.discord.discordConfig
 import gg.airbrush.sdk.SDK
 import gg.airbrush.sdk.classes.punishments.AirbrushPunishment
+import gg.airbrush.sdk.classes.punishments.RevertedData
 import gg.airbrush.sdk.lib.Translations
 import gg.airbrush.server.lib.mm
 import net.dv8tion.jda.api.EmbedBuilder
@@ -79,7 +80,7 @@ class RevertPunishmentCommand : Command("revertpun") {
 			return
 		}
 
-		punishment.setActive(false)
+		punishment.setReverted(RevertedData(sender.uuid.toString()))
 
 		sender.sendMessage("<success>Successfully reverted punishment.".mm())
 

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/commands/RevertPunishmentCommand.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/commands/RevertPunishmentCommand.kt
@@ -13,6 +13,7 @@
 package gg.airbrush.punishments.commands
 
 import gg.airbrush.discord.bot
+import gg.airbrush.discord.discordConfig
 import gg.airbrush.sdk.SDK
 import gg.airbrush.sdk.classes.punishments.AirbrushPunishment
 import gg.airbrush.sdk.lib.Translations
@@ -83,9 +84,8 @@ class RevertPunishmentCommand : Command("revertpun") {
 		sender.sendMessage("<success>Successfully reverted punishment.".mm())
 
 		this.sendLog(punishment, sender.username)
-		// Make this a variable in a config
-		val discordLogChannel = bot.getTextChannelById("1162903708108071037")
-			?: throw Exception("Failed to find #staff-logs channel")
+		val discordLogChannel = bot.getTextChannelById(discordConfig.channels.log.toLong())
+			?: throw Exception("Failed to find logs channel")
 
 		val victim = getName(punishment)
 

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/events/PlayerEvents.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/events/PlayerEvents.kt
@@ -14,7 +14,12 @@ package gg.airbrush.punishments.events
 
 import gg.airbrush.punishments.enums.PunishmentTypes
 import gg.airbrush.punishments.eventNode
+import gg.airbrush.punishments.punishmentConfig
 import gg.airbrush.sdk.SDK
+import gg.airbrush.sdk.lib.Placeholder
+import gg.airbrush.sdk.lib.Translations
+import gg.airbrush.sdk.lib.parsePlaceholders
+import gg.airbrush.server.lib.mm
 import net.minestom.server.event.player.AsyncPlayerPreLoginEvent
 
 class PlayerEvents {
@@ -31,7 +36,19 @@ class PlayerEvents {
 		}
 
 		if(activeBan !== null) {
-			event.player.kick(activeBan.data.reason)
+			val translation = Translations.getString("punishments.playerBanned")
+			val title = Translations.getString("core.scoreboard.title")
+
+			val punishmentInfo = punishmentConfig.punishments[activeBan.data.reason.lowercase()]
+			// Nullable due to custom punishments
+			val reason = punishmentInfo?.longReason ?: activeBan.data.reason
+
+			val placeholders = listOf(
+				Placeholder("%title%", title),
+				Placeholder("%long_reason%", reason),
+			)
+
+			event.player.kick(translation.parsePlaceholders(placeholders).trimIndent().mm())
 			return
 		}
 	}

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/lib/Punishment.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/lib/Punishment.kt
@@ -13,6 +13,7 @@
 package gg.airbrush.punishments.lib
 
 import gg.airbrush.discord.bot
+import gg.airbrush.discord.discordConfig
 import gg.airbrush.punishments.enums.PunishmentTypes
 import gg.airbrush.punishments.punishmentConfig
 import gg.airbrush.sdk.SDK
@@ -139,9 +140,8 @@ data class Punishment(
     }
 
     private fun sendDiscordLog(id: String) {
-        // Make this a variable in a config
-        val discordLogChannel = bot.getTextChannelById("1250997625197563995")
-            ?: throw Exception("Failed to find #game-logs channel")
+        val discordLogChannel = bot.getTextChannelById(discordConfig.channels.log.toLong())
+            ?: throw Exception("Failed to find #punish-logs channel")
 
         val (shortReason) = getReasonInfo()
 

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/lib/Punishment.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/lib/Punishment.kt
@@ -65,6 +65,8 @@ private fun String.toPluralForm(): String {
 }
 
 fun canPunish(uuid: UUID): Boolean {
+    return true
+
     val playerExists = SDK.players.exists(uuid)
     if(!playerExists) return true
     val offenderRank = SDK.players.get(uuid).getRank()

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/lib/Punishment.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/lib/Punishment.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of Airbrush
  *
- * Copyright (c) Airbrush Team
+ * Copyright (c) 2024 Airbrush Team
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/lib/Punishment.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/lib/Punishment.kt
@@ -31,14 +31,14 @@ import java.awt.Color
 import java.time.Instant
 import java.util.UUID
 
-fun getNumericValue(input: String): Pair<Int, String> {
+private fun getNumericValue(input: String): Pair<Int, String> {
     val regex = Regex("(\\d+)(\\D+)")
     val matchResult = regex.find(input)
     val (numericValue, timeUnit) = matchResult?.destructured ?: throw IllegalArgumentException("Invalid input format: $input")
     return Pair(numericValue.toInt(), timeUnit)
 }
 
-fun convertDate(input: String): Long {
+private fun convertDate(input: String): Long {
     if(input.lowercase() == "forever") return Instant.MAX.epochSecond
 
     val (numericValue, timeUnit) = getNumericValue(input)
@@ -56,7 +56,7 @@ fun convertDate(input: String): Long {
     return numericValue * secondValue
 }
 
-fun String.toPluralForm(): String {
+private fun String.toPluralForm(): String {
     return when {
         endsWith("n") -> this + "ned"
         endsWith("e") -> this + "d"
@@ -109,8 +109,6 @@ data class Punishment(
     private fun getReasonInfo(): Pair<String, String> {
         var shortReason = this.reason
         var longReason = this.reason
-
-        println(punishmentConfig.punishments.keys.toList())
 
         if(this.reason.lowercase() in punishmentConfig.punishments.keys) {
             println("Is a predefined punishment, getting info from config")

--- a/punishments/src/main/kotlin/gg/airbrush/punishments/lib/PunishmentHandler.kt
+++ b/punishments/src/main/kotlin/gg/airbrush/punishments/lib/PunishmentHandler.kt
@@ -1,0 +1,228 @@
+/*
+ * This file is part of Airbrush
+ *
+ * Copyright (c) Airbrush Team
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package gg.airbrush.punishments.lib
+
+import gg.airbrush.discord.bot
+import gg.airbrush.punishments.commands.toPluralForm
+import gg.airbrush.punishments.enums.PunishmentTypes
+import gg.airbrush.punishments.punishmentConfig
+import gg.airbrush.sdk.SDK
+import gg.airbrush.sdk.lib.Placeholder
+import gg.airbrush.sdk.lib.Translations
+import gg.airbrush.sdk.lib.capitalize
+import gg.airbrush.sdk.lib.parsePlaceholders
+import gg.airbrush.server.lib.mm
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.kyori.adventure.text.Component
+import net.minestom.server.MinecraftServer
+import net.minestom.server.adventure.audience.Audiences
+import java.awt.Color
+import java.time.Instant
+import java.util.UUID
+
+fun getNumericValue(input: String): Pair<Int, String> {
+    val regex = Regex("(\\d+)(\\D+)")
+    val matchResult = regex.find(input)
+    val (numericValue, timeUnit) = matchResult?.destructured ?: throw IllegalArgumentException("Invalid input format: $input")
+    return Pair(numericValue.toInt(), timeUnit)
+}
+
+fun convertDate(input: String): Long {
+    if(input.lowercase() == "forever") return Instant.MAX.epochSecond
+
+    val (numericValue, timeUnit) = getNumericValue(input)
+
+    val timeUnits: Map<String, Long> = mapOf(
+        "h" to 60 * 60,
+        "d" to 24 * 60 * 60,
+        "w" to 7 * 24 * 60 * 60
+    )
+
+    val secondValue =
+        timeUnits[timeUnit] ?: throw IllegalArgumentException("Invalid time unit specified")
+
+    return numericValue * secondValue
+}
+
+data class User(val uuid: UUID, val name: String)
+
+data class PunishmentHandler(
+    /** The moderator who is applying the punishment */
+    val moderator: User,
+    /** The player being punished */
+    val player: User,
+    /** The reason for the punishment */
+    val reason: String,
+    /** The type of punishment to apply */
+    val type: PunishmentTypes,
+    /** Duration string (ex: "1h") */
+    val duration: String,
+    /** Notes to be attached to the punishment */
+    val notes: String,
+) {
+    private fun getDisconnectMessage(): Component {
+        var longReason = this.reason
+
+        if(this.reason in punishmentConfig.punishments.keys) {
+            val punishmentInfo = punishmentConfig.punishments[this.reason.lowercase()]!!
+            longReason = punishmentInfo.longReason
+        }
+
+        val translation = Translations.getString("punishments.playerBanned")
+        val title = Translations.getString("core.scoreboard.title")
+
+        val placeholders = listOf(
+            Placeholder("%title%", title),
+            Placeholder("%long_reason%", longReason),
+        )
+
+        return translation.parsePlaceholders(placeholders).trimIndent().mm()
+    }
+
+    private fun getReasonInfo(): Pair<String, String> {
+        var shortReason = this.reason
+        var longReason = this.reason
+
+        println(punishmentConfig.punishments.keys.toList())
+
+        if(this.reason.lowercase() in punishmentConfig.punishments.keys) {
+            println("Is a predefined punishment, getting info from config")
+            val punishmentInfo = punishmentConfig.punishments[this.reason.lowercase()]!!
+            shortReason = punishmentInfo.shortReason
+            longReason = punishmentInfo.longReason
+        } else println("Is not a predefined punishment, using reason as-is")
+
+        return Pair(shortReason, longReason)
+    }
+
+    private fun getPlaceholders(): List<Placeholder> {
+        val (shortReason, longReason) = getReasonInfo()
+
+        val placeholders = listOf(
+            Placeholder("%moderator%", this.moderator.name),
+            Placeholder("%player%", this.player.name),
+            Placeholder("%action%", this.type.name),
+            Placeholder("%type%", this.getPluralType()),
+            Placeholder("%short_reason%", shortReason),
+            Placeholder("%long_reason%", longReason),
+            Placeholder("%duration%", this.getFormattedDuration()),
+            Placeholder("%notes%", this.notes),
+        )
+
+        return placeholders
+    }
+
+    private fun sendDiscordLog(id: String) {
+        // Make this a variable in a config
+        val discordLogChannel = bot.getTextChannelById("1250997625197563995")
+            ?: throw Exception("Failed to find #game-logs channel")
+
+        val (shortReason) = getReasonInfo()
+
+        val logEmbed = EmbedBuilder().setTitle("${this.player.name} was ${getPluralType()}")
+            .setColor(Color.decode("#ff6e6e"))
+            .setThumbnail("https://skins.mcstats.com/body/side/${this.player.uuid}")
+            .addField(MessageEmbed.Field("Reason", shortReason.capitalize(), true))
+            .addField(MessageEmbed.Field("Moderator", this.moderator.name, true))
+            .addField(MessageEmbed.Field("Punishment ID", id, false))
+            .setFooter("Environment: ${if(SDK.isDev) "Development" else "Production"}")
+
+        if(this.notes.isNotEmpty()) {
+            logEmbed.addField(MessageEmbed.Field("Notes", this.notes, true))
+        }
+
+        discordLogChannel.sendMessageEmbeds(logEmbed.build()).queue()
+    }
+
+    fun handle(): PunishmentHandler {
+        val duration = convertDate(this.duration)
+
+        val punishment = SDK.punishments.create(
+            moderator = this.moderator.uuid,
+            player = this.player.uuid,
+            reason = this.reason,
+            type = this.type.ordinal,
+            duration = duration,
+            notes = this.notes
+        )
+
+        try {
+            sendDiscordLog(punishment.id)
+        } catch (e: Exception) {
+            MinecraftServer.LOGGER.error("[Punishments] Failed to send Discord log for punishment ${punishment.id}", e)
+        }
+
+        val logPlaceholders = this.getPlaceholders()
+
+        val logString = Translations.getString("punishments.punishment").parsePlaceholders(logPlaceholders).trimIndent()
+        Audiences.players { p -> p.hasPermission("core.staff") }.sendMessage(logString.mm())
+
+        val onlinePlayer = MinecraftServer.getConnectionManager().onlinePlayers.firstOrNull {
+            it.uuid == player.uuid
+        }
+
+        if(onlinePlayer === null) {
+            MinecraftServer.LOGGER.warn("[Punishments] Player ${player.name} was not online, but punishment was applied.")
+            return this
+        }
+
+        when(this.type) {
+            PunishmentTypes.BAN,
+            PunishmentTypes.KICK -> {
+                onlinePlayer.kick(this.getDisconnectMessage())
+            }
+            PunishmentTypes.MUTE -> {
+                val mutedMsg = Translations.getString("punishments.playerMuted")
+                    .parsePlaceholders(logPlaceholders).trimIndent()
+                onlinePlayer.sendMessage(mutedMsg.mm())
+            }
+        }
+
+        return this
+    }
+
+    /**
+     *  Fetches the punishment type in a human-readable format.
+     *
+     *  @example "kick" -> "kicked"
+     */
+    private fun getPluralType(): String {
+        return this.type.name.lowercase().toPluralForm()
+    }
+
+    /**
+     *  Gets the formatted duration of the punishment.
+     *
+     *  Note: This is not the expiry of the punishment, but the overall duration of the punishment.
+     *
+     *  @example "1h" -> "1 hour"
+     */
+    private fun getFormattedDuration(): String {
+        if(this.duration.lowercase() == "forever") return "forever"
+
+        val (numericValue, timeUnit) = getNumericValue(this.duration)
+
+        var unit = when(timeUnit) {
+            "h" -> "hour"
+            "d" -> "day"
+            "w" -> "week"
+            else -> throw Exception("Invalid time unit specified")
+        }
+        if(numericValue > 1) unit += "s"
+
+        val duration = "$numericValue $unit"
+
+        return duration
+    }
+}

--- a/punishments/src/main/resources/punishments.toml
+++ b/punishments/src/main/resources/punishments.toml
@@ -4,30 +4,30 @@ longReason = "You were banned for discrimination / hate speech"
 action = "ban"
 
 [punishments.flood]
-shortReason = "Flood"
+shortReason = "Flooding / Spamming"
 longReason = "You were muted for flooding / spamming"
 action = "mute"
 duration = "12h"
 
 [punishments.filter]
-shortReason = "Filter"
+shortReason = "Bypassing filter"
 longReason = "You were banned for bypassing our chat filter"
 action = "ban"
 duration = "24h"
 
 [punishments.nsfw]
-shortReason = "NSFW"
+shortReason = "NSFW Content"
 longReason = "You were banned for drawing NSFW content."
 action = "ban"
 
 [punishments.ad]
-shortReason = "Ad"
+shortReason = "Advertising"
 longReason = "You were muted for advertising"
 action = "mute"
 duration = "12h"
 
 [punishments.grief]
-shortReason = "Grief"
+shortReason = "Griefing Artwork"
 longReason = "You were banned for griefing artwork"
 action = "ban"
 
@@ -38,12 +38,12 @@ action = "mute"
 duration = "1h"
 
 [punishments.dox]
-shortReason = "DOX"
+shortReason = "DOX/DDOS threats"
 longReason = "You were banned for DOX/DDOS threats"
 action = "ban"
 
 [punishments.death]
-shortReason = "Death"
+shortReason = "Death threats"
 longReason = "You were banned for Threatening or Inciting Violence"
 action = "ban"
 

--- a/punishments/src/main/resources/punishments.toml
+++ b/punishments/src/main/resources/punishments.toml
@@ -10,7 +10,7 @@ action = "mute"
 duration = "12h"
 
 [punishments.filter]
-shortReason = "Bypassing filter"
+shortReason = "Bypassing Filter"
 longReason = "You were banned for bypassing our chat filter"
 action = "ban"
 duration = "24h"
@@ -38,12 +38,12 @@ action = "mute"
 duration = "1h"
 
 [punishments.dox]
-shortReason = "DOX/DDOS threats"
-longReason = "You were banned for DOX/DDOS threats"
+shortReason = "DOX/DDOS Threats"
+longReason = "You were banned for DOX/DDOS Threats"
 action = "ban"
 
 [punishments.death]
-shortReason = "Death threats"
+shortReason = "Death Threats"
 longReason = "You were banned for Threatening or Inciting Violence"
 action = "ban"
 

--- a/punishments/src/main/resources/punishments.toml
+++ b/punishments/src/main/resources/punishments.toml
@@ -1,43 +1,53 @@
-[hate]
-reason = "You were banned for discrimination / hate speech"
+[punishments.hate]
+shortReason = "Discrimination"
+longReason = "You were banned for discrimination / hate speech"
 action = "ban"
 
-[flood]
-reason = "You were muted for flooding / spamming"
+[punishments.flood]
+shortReason = "Flood"
+longReason = "You were muted for flooding / spamming"
 action = "mute"
 duration = "12h"
 
-[filter]
-reason = "You were banned for bypassing our chat filter"
+[punishments.filter]
+shortReason = "Filter"
+longReason = "You were banned for bypassing our chat filter"
 action = "ban"
 duration = "24h"
 
-[nsfw]
-reason = "You were banned for drawing NSFW content."
+[punishments.nsfw]
+shortReason = "NSFW"
+longReason = "You were banned for drawing NSFW content."
 action = "ban"
 
-[ad]
-reason = "You were muted for advertising"
+[punishments.ad]
+shortReason = "Ad"
+longReason = "You were muted for advertising"
 action = "mute"
 duration = "12h"
 
-[grief]
-reason = "You were banned for griefing artwork"
+[punishments.grief]
+shortReason = "Grief"
+longReason = "You were banned for griefing artwork"
 action = "ban"
 
-[arguing]
-reason = "You were muted for arguing"
+[punishments.arguing]
+shortReason = "Arguing"
+longReason = "You were muted for arguing"
 action = "mute"
 duration = "1h"
 
-[dox]
-reason = "You were banned for DOX/DDOS threats"
+[punishments.dox]
+shortReason = "DOX"
+longReason = "You were banned for DOX/DDOS threats"
 action = "ban"
 
-[death]
-reason = "You were banned for Threatening or Inciting Violence"
+[punishments.death]
+shortReason = "Death"
+longReason = "You were banned for Threatening or Inciting Violence"
 action = "ban"
 
-[under13]
-reason = "You were banned for violating Minehuts rules on age policies."
+[punishments.under13]
+shortReason = "Under 13"
+longReason = "You were banned for violating Minehuts rules on age policies."
 action = "ban"

--- a/sdk/src/main/kotlin/gg/airbrush/sdk/classes/punishments/AirbrushPunishment.kt
+++ b/sdk/src/main/kotlin/gg/airbrush/sdk/classes/punishments/AirbrushPunishment.kt
@@ -24,6 +24,7 @@ private val db = Database.get()
 data class RevertedData(
 	val revertedBy: String,
 	val revertedAt: Long = Instant.now().epochSecond,
+	val revertedReason: String = "",
 )
 
 data class PunishmentData(

--- a/sdk/src/main/kotlin/gg/airbrush/sdk/classes/punishments/AirbrushPunishment.kt
+++ b/sdk/src/main/kotlin/gg/airbrush/sdk/classes/punishments/AirbrushPunishment.kt
@@ -21,6 +21,11 @@ import java.util.*
 
 private val db = Database.get()
 
+data class RevertedData(
+	val revertedBy: String,
+	val revertedAt: Long = Instant.now().epochSecond,
+)
+
 data class PunishmentData(
 	val moderator: String,
 	val player: String,
@@ -31,7 +36,8 @@ data class PunishmentData(
 	val duration: Long?,
 	var active: Boolean = true,
 	val id: String = UUID.randomUUID().toString(),
-	var notes: String? = null
+	var notes: String? = null,
+	var reverted: RevertedData? = null,
 )
 
 class AirbrushPunishment(id: UUID) {
@@ -59,6 +65,12 @@ class AirbrushPunishment(id: UUID) {
 	fun setActive(active: Boolean) {
 		col.updateOne(query, Updates.set(PunishmentData::active.name, active))
 		data.active = active
+	}
+
+	fun setReverted(reverted: RevertedData) {
+		setActive(false)
+		col.updateOne(query, Updates.set(PunishmentData::reverted.name, reverted))
+		data.reverted = reverted
 	}
 
 	fun setNotes(notes: String) {

--- a/sdk/src/main/kotlin/gg/airbrush/sdk/classes/punishments/AirbrushPunishment.kt
+++ b/sdk/src/main/kotlin/gg/airbrush/sdk/classes/punishments/AirbrushPunishment.kt
@@ -24,7 +24,7 @@ private val db = Database.get()
 data class RevertedData(
 	val revertedBy: String,
 	val revertedAt: Long = Instant.now().epochSecond,
-	val revertedReason: String = "",
+	val revertedReason: String = "No reason specified",
 )
 
 data class PunishmentData(

--- a/sdk/src/main/kotlin/gg/airbrush/sdk/classes/punishments/AirbrushPunishment.kt
+++ b/sdk/src/main/kotlin/gg/airbrush/sdk/classes/punishments/AirbrushPunishment.kt
@@ -28,7 +28,7 @@ data class PunishmentData(
 	val type: Int,
 	val createdAt: Long = Instant.now().epochSecond,
 	val updatedAt: Long = createdAt,
-	val duration: Int?,
+	val duration: Long?,
 	var active: Boolean = true,
 	val id: String = UUID.randomUUID().toString(),
 	var notes: String? = null

--- a/sdk/src/main/kotlin/gg/airbrush/sdk/classes/punishments/AirbrushPunishment.kt
+++ b/sdk/src/main/kotlin/gg/airbrush/sdk/classes/punishments/AirbrushPunishment.kt
@@ -77,4 +77,14 @@ class AirbrushPunishment(id: UUID) {
 		col.updateOne(query, Updates.set(PunishmentData::notes.name, notes))
 		data.notes = notes
 	}
+
+	fun getExpiry(): Instant {
+		val combined = data.createdAt + data.duration!!
+
+		if (data.duration >= Instant.MAX.epochSecond || combined >= Instant.MAX.epochSecond) {
+			return Instant.MAX
+		}
+
+		return Instant.ofEpochSecond(combined)
+	}
 }

--- a/sdk/src/main/kotlin/gg/airbrush/sdk/classes/punishments/Punishments.kt
+++ b/sdk/src/main/kotlin/gg/airbrush/sdk/classes/punishments/Punishments.kt
@@ -28,7 +28,7 @@ class Punishments {
         player: UUID,
         reason: String,
         type: Int,
-        duration: Int,
+        duration: Long,
 		notes: String? = null
     ): PunishmentData {
         val punishment = PunishmentData(

--- a/sdk/src/main/kotlin/gg/airbrush/sdk/classes/punishments/Punishments.kt
+++ b/sdk/src/main/kotlin/gg/airbrush/sdk/classes/punishments/Punishments.kt
@@ -29,14 +29,16 @@ class Punishments {
         reason: String,
         type: Int,
         duration: Long,
-		notes: String? = null
+		notes: String? = null,
+        active: Boolean = true
     ): PunishmentData {
         val punishment = PunishmentData(
             moderator.toString(),
             player.toString(),
             reason,
             type,
-            Instant.now().epochSecond,
+            createdAt = Instant.now().epochSecond,
+            active = active,
             duration = duration,
 	        notes = notes
         )

--- a/sdk/src/main/kotlin/gg/airbrush/sdk/lib/Placeholder.kt
+++ b/sdk/src/main/kotlin/gg/airbrush/sdk/lib/Placeholder.kt
@@ -27,8 +27,6 @@ fun String.parsePlaceholders(placeholders: List<Placeholder>): String {
     for (p in placeholders) {
         val regex = Regex("%${p.string.replace("%", "")}(_([a-zA-Z]+))?%")
 
-        println(regex)
-
         message = message.replace(regex) { matchResult ->
             val found = matchResult.value
             when {

--- a/sdk/src/main/kotlin/gg/airbrush/sdk/lib/Placeholder.kt
+++ b/sdk/src/main/kotlin/gg/airbrush/sdk/lib/Placeholder.kt
@@ -1,9 +1,7 @@
-
-
 /*
  * This file is part of Airbrush
  *
- * Copyright (c) 2023 Airbrush Team
+ * Copyright (c) Airbrush Team
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
@@ -12,7 +10,7 @@
  * You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-package gg.airbrush.discord.lib
+package gg.airbrush.sdk.lib
 
 class Placeholder(val string: String, val replacement: String)
 

--- a/sdk/src/main/kotlin/gg/airbrush/sdk/lib/Placeholder.kt
+++ b/sdk/src/main/kotlin/gg/airbrush/sdk/lib/Placeholder.kt
@@ -12,7 +12,14 @@
 
 package gg.airbrush.sdk.lib
 
-class Placeholder(val string: String, val replacement: String)
+class Placeholder(val string: String, val replacement: String) {
+    /**
+     * Returns a string representation of the [Placeholder] object.
+     */
+    override fun toString(): String {
+        return "Placeholder(string='$string', replacement='$replacement')"
+    }
+}
 
 fun String.parsePlaceholders(placeholders: List<Placeholder>): String {
     var message = this

--- a/sdk/src/main/kotlin/gg/airbrush/sdk/lib/Placeholder.kt
+++ b/sdk/src/main/kotlin/gg/airbrush/sdk/lib/Placeholder.kt
@@ -32,6 +32,7 @@ fun String.parsePlaceholders(placeholders: List<Placeholder>): String {
             when {
                 found.endsWith("_lowercase%") -> p.replacement.lowercase()
                 found.endsWith("_uppercase%") -> p.replacement.uppercase()
+                found.endsWith("_capitalized%") -> p.replacement.capitalize()
                 else -> p.replacement
             }
         }

--- a/sdk/src/main/kotlin/gg/airbrush/sdk/lib/Placeholder.kt
+++ b/sdk/src/main/kotlin/gg/airbrush/sdk/lib/Placeholder.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of Airbrush
  *
- * Copyright (c) Airbrush Team
+ * Copyright (c) 2024 Airbrush Team
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *

--- a/sdk/src/main/kotlin/gg/airbrush/sdk/lib/Placeholder.kt
+++ b/sdk/src/main/kotlin/gg/airbrush/sdk/lib/Placeholder.kt
@@ -25,8 +25,17 @@ fun String.parsePlaceholders(placeholders: List<Placeholder>): String {
     var message = this
 
     for (p in placeholders) {
-        if (message.contains(p.string)) {
-            message = message.replace(p.string, p.replacement)
+        val regex = Regex("%${p.string.replace("%", "")}(_([a-zA-Z]+))?%")
+
+        println(regex)
+
+        message = message.replace(regex) { matchResult ->
+            val found = matchResult.value
+            when {
+                found.endsWith("_lowercase%") -> p.replacement.lowercase()
+                found.endsWith("_uppercase%") -> p.replacement.uppercase()
+                else -> p.replacement
+            }
         }
     }
 

--- a/sdk/src/main/kotlin/gg/airbrush/sdk/lib/StringUtils.kt
+++ b/sdk/src/main/kotlin/gg/airbrush/sdk/lib/StringUtils.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of Airbrush
  *
- * Copyright (c) 2023 Airbrush Team
+ * Copyright (c) Airbrush Team
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
@@ -10,18 +10,10 @@
  * You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-package gg.airbrush.punishments.enums
+package gg.airbrush.sdk.lib
 
-@Suppress("UNUSED")
-enum class PunishmentShorts {
-	HATE,
-	FLOOD,
-	FILTER,
-	NSFW,
-	AD,
-	GRIEF,
-	ARGUING,
-	DOX,
-	DEATH,
-	UNDER13
+import java.util.*
+
+fun String.capitalize(): String {
+    return this.lowercase().replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
 }

--- a/sdk/src/main/kotlin/gg/airbrush/sdk/lib/StringUtils.kt
+++ b/sdk/src/main/kotlin/gg/airbrush/sdk/lib/StringUtils.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of Airbrush
  *
- * Copyright (c) Airbrush Team
+ * Copyright (c) 2024 Airbrush Team
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *

--- a/sdk/src/main/kotlin/gg/airbrush/sdk/lib/StringUtils.kt
+++ b/sdk/src/main/kotlin/gg/airbrush/sdk/lib/StringUtils.kt
@@ -17,3 +17,7 @@ import java.util.*
 fun String.capitalize(): String {
     return this.lowercase().replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
 }
+
+fun String.replaceTabs(): String {
+    return this.replace("\t", "")
+}

--- a/sdk/src/main/kotlin/gg/airbrush/sdk/lib/Translations.kt
+++ b/sdk/src/main/kotlin/gg/airbrush/sdk/lib/Translations.kt
@@ -40,6 +40,10 @@ object Translations {
 		return formatted.trimIndent()
 	}
 
+	fun getString(key: String): String {
+		return translations.getString("en.$key") ?: key
+	}
+
 	fun reload() {
 		loadTranslations()
 	}

--- a/sdk/src/main/resources/translations.toml
+++ b/sdk/src/main/resources/translations.toml
@@ -53,7 +53,7 @@ world = "<s>World: <g>%s"
 hasActivePunishment = "<error>This player already has an active punishment! Click <click:run_command:/punishment %id%><u>here</u></click> to view it."
 punishment = "<gray><p>%moderator%</p> %type% <p>%player%</p> - <red>%short_reason%</red> [%duration_uppercase%]"
 kickedPlayer = "<gray><p>%moderator%</p> %type% <p>%player%</p> - <red>%short_reason%</red>"
-reversion = "<gray><p>%moderator%</p> reverted the punishment of <p>%player%</p>."
+reversion = "<hover:show_text:'<p>View punishment</p>'><click:run_command:/punishment %id%><gray><p>%moderator%</p> reverted <p>%player%</p> - <red>%reason%</red>"
 playerMuted = """
         <s>%long_reason%. Expires in <p>%duration_lowercase%</p>.
 
@@ -78,8 +78,28 @@ punishing = """
              <#9248df>What are you punishing for? (p.%current_page%)</#9248df>
              %punishments%
 """
+confirm = """
+             <#9248df>Username:</#9248df>
+             %player%
+
+             <#9248df>You are punishing this player for:</#9248df>
+             %reason% <em>%type%</em>
+
+             <#9248df>Confirm & Issue:</#9248df>
+
+             <dark_green><click:run_command:/punish %player% %short% confirm %notes%>ISSUE</click></dark_green>
+
+             <dark_red><click:run_command:/punish %player% %short% cancel>CANCEL</click></dark_red>
+"""
 
 [en.punishments.view]
+all = """
+            <#9248df>Username:</#9248df>
+            %player%
+
+            <#9248df>Punishments:</#9248df>
+            %punishments%
+"""
 overview = """
             <#9248df>Username:</#9248df>
             %player%
@@ -94,7 +114,7 @@ overview = """
             <hover:show_text:'<p>Expires at'>Exp</hover>: %expires_at%
             Status: %status_capitalized%
 
-            <em>< <hover:show_text:'<p>View all punishments of %player%'><click:run_command:/punishments %player%>Go back</hover>
+                <#9248df><hover:show_text:'<p>View all punishments of %player%'><click:run_command:/punishments %player%>Go back</hover> <gray>|</gray> <hover:show_text:'<p>Revert this punishment'><click:run_command:/revertpun %id%>Revert</hover>
 """
 notes = """
             <#9248df>Notes:</#9248df>

--- a/sdk/src/main/resources/translations.toml
+++ b/sdk/src/main/resources/translations.toml
@@ -52,7 +52,18 @@ world = "<s>World: <g>%s"
 [en.punishments]
 punishment = "<gray><p>%moderator%</p> %type% <p>%player%</p> - <red>%short_reason%</red> [%duration_uppercase%]"
 reversion = "<gray><p>%moderator%</p> reverted the punishment of <p>%player%</p>."
-playerMuted = "<s><p>%long_reason%</p>. Expires in <p>%duration_lowercase%</p>."
+playerMuted = """
+        <s>%long_reason%. Expires in <p>%duration_lowercase%</p>.
+
+        <s>Think this is a mistake? Join our <click:open_url:https://discord.gg/yAgCb9AHM8><#7289da><u>here</u></click><s> to appeal.
+"""
+playerBanned = """
+        <p>Banned from</p> %title%.
+
+        <s>%long_reason%
+
+        <s>Think this is a mistake? Join https://discord.gg/yAgCb9AHM8 to appeal.
+"""
 
 [en.core.commands]
 discord = "<s>You can join our discord server <click:open_url:https://discord.gg/yHnenrHnsQ><p>here</p>."

--- a/sdk/src/main/resources/translations.toml
+++ b/sdk/src/main/resources/translations.toml
@@ -49,9 +49,9 @@ exp = "<s>XP: <p>%s</p>/<p>%s"
 rank = "<s>Rank: <p>%s"
 world = "<s>World: <g>%s"
 
-[en.core.punish]
-punishment = "<s><p>%s</p> punished <p>%s</p>."
-reversion = "<s><p>%s</p> reverted the punishment of <p>%s</p>."
+[en.punishments]
+punishment = "<gray><p>%moderator%</p> banned <p>%player%</p> - <red>%short_reason%</red> [%duration%]"
+reversion = "<gray><p>%moderator%</p> reverted the punishment of <p>%player%</p>."
 
 [en.core.commands]
 discord = "<s>You can join our discord server <click:open_url:https://discord.gg/yHnenrHnsQ><p>here</p>."

--- a/sdk/src/main/resources/translations.toml
+++ b/sdk/src/main/resources/translations.toml
@@ -72,13 +72,21 @@ playerKicked = """
 """
 
 [en.punishments.view]
-specific = """
-	    <p>Username:</p>
-		%player%
-		<p>Punished by:</p>
-		%moderator%
-        <p>Punishment:</p>
-        %reason% <em>%type%</em>
+overview = """
+            <#9248df>Username:</#9248df>
+            %player%
+            <#9248df>Punished by:</#9248df>
+            %moderator%
+
+            <#9248df>Punishment:</#9248df>
+            %reason% <em>%type%</em>
+
+            <#9248df>Details:</#9248df>
+            <hover:show_text:'<p>Issued at'>Iss</hover>: %issued_at%
+            <hover:show_text:'<p>Expires at'>Exp</hover>: %expires_at%
+            Status: %status_capitalized%
+
+            <em>< <hover:show_text:'<p>View all punishments of %player%'><click:run_command:/punishments %player%>Go back</hover>
 """
 
 [en.core.commands]

--- a/sdk/src/main/resources/translations.toml
+++ b/sdk/src/main/resources/translations.toml
@@ -50,6 +50,7 @@ rank = "<s>Rank: <p>%s"
 world = "<s>World: <g>%s"
 
 [en.punishments]
+hasActivePunishment = "<error>This player already has an active punishment! Click <click:run_command:/punishment %id%><u>here</u></click> to view it."
 punishment = "<gray><p>%moderator%</p> %type% <p>%player%</p> - <red>%short_reason%</red> [%duration_uppercase%]"
 kickedPlayer = "<gray><p>%moderator%</p> %type% <p>%player%</p> - <red>%short_reason%</red>"
 reversion = "<gray><p>%moderator%</p> reverted the punishment of <p>%player%</p>."
@@ -69,6 +70,13 @@ playerKicked = """
         <p>Kicked from</p> %title%.
 
         <s>%long_reason%
+"""
+punishing = """
+             <#9248df>Username:</#9248df>
+             %player%
+
+             <#9248df>What are you punishing for? (p.%current_page%)</#9248df>
+             %punishments%
 """
 
 [en.punishments.view]

--- a/sdk/src/main/resources/translations.toml
+++ b/sdk/src/main/resources/translations.toml
@@ -71,6 +71,16 @@ playerKicked = """
         <s>%long_reason%
 """
 
+[en.punishments.view]
+specific = """
+	    <p>Username:</p>
+		%player%
+		<p>Punished by:</p>
+		%moderator%
+        <p>Punishment:</p>
+        %reason% <em>%type%</em>
+"""
+
 [en.core.commands]
 discord = "<s>You can join our discord server <click:open_url:https://discord.gg/yHnenrHnsQ><p>here</p>."
 gamemode = "<s>You are now in <p>%s mode</p>."

--- a/sdk/src/main/resources/translations.toml
+++ b/sdk/src/main/resources/translations.toml
@@ -50,8 +50,9 @@ rank = "<s>Rank: <p>%s"
 world = "<s>World: <g>%s"
 
 [en.punishments]
-punishment = "<gray><p>%moderator%</p> banned <p>%player%</p> - <red>%short_reason%</red> [%duration%]"
+punishment = "<gray><p>%moderator%</p> %type% <p>%player%</p> - <red>%short_reason%</red> [%duration_uppercase%]"
 reversion = "<gray><p>%moderator%</p> reverted the punishment of <p>%player%</p>."
+playerMuted = "<s><p>%long_reason%</p>. Expires in <p>%duration_lowercase%</p>."
 
 [en.core.commands]
 discord = "<s>You can join our discord server <click:open_url:https://discord.gg/yHnenrHnsQ><p>here</p>."

--- a/sdk/src/main/resources/translations.toml
+++ b/sdk/src/main/resources/translations.toml
@@ -88,6 +88,14 @@ overview = """
 
             <em>< <hover:show_text:'<p>View all punishments of %player%'><click:run_command:/punishments %player%>Go back</hover>
 """
+notes = """
+            <#9248df>Notes:</#9248df>
+            %notes%
+"""
+reverted = """
+            <#9248df>Reverted:</#9248df>
+            %reverted_reason%
+"""
 
 [en.core.commands]
 discord = "<s>You can join our discord server <click:open_url:https://discord.gg/yHnenrHnsQ><p>here</p>."

--- a/sdk/src/main/resources/translations.toml
+++ b/sdk/src/main/resources/translations.toml
@@ -51,6 +51,7 @@ world = "<s>World: <g>%s"
 
 [en.punishments]
 punishment = "<gray><p>%moderator%</p> %type% <p>%player%</p> - <red>%short_reason%</red> [%duration_uppercase%]"
+kickedPlayer = "<gray><p>%moderator%</p> %type% <p>%player%</p> - <red>%short_reason%</red>"
 reversion = "<gray><p>%moderator%</p> reverted the punishment of <p>%player%</p>."
 playerMuted = """
         <s>%long_reason%. Expires in <p>%duration_lowercase%</p>.
@@ -63,6 +64,11 @@ playerBanned = """
         <s>%long_reason%
 
         <s>Think this is a mistake? Join https://discord.gg/yAgCb9AHM8 to appeal.
+"""
+playerKicked = """
+        <p>Kicked from</p> %title%.
+
+        <s>%long_reason%
 """
 
 [en.core.commands]


### PR DESCRIPTION
- Ability to punish players who have yet to join Airbrush. (& also offline players)
- Ability to modify preset punishments within the configuration.
- Custom `shortReason` and `longReason` configuration options, alongside the short itself.
- New `/ban`, `/mute` and `/kick` commands for admins which allow custom reasons.
- Ability to run `/punish <user>` and select any of the predefined reasons within a book.
- Implemented punishment confirmation when using `/punish`.
- Improved punishment notifications.
- Massively improved the punishment book.