### PR TITLE
fix: blocks carrying over from player worlds

### DIFF
--- a/core/src/main/kotlin/gg/airbrush/core/events/PlayerLogin.kt
+++ b/core/src/main/kotlin/gg/airbrush/core/events/PlayerLogin.kt
@@ -102,10 +102,9 @@ class PlayerLogin {
         }
 
         player.isAllowFlying = true
+        player.giveItems(sdkPlayer)
 
         if (event.isFirstSpawn) {
-            player.giveItems(sdkPlayer)
-
             val joinInfo = Translations.translate("core.welcome", player.username)
             player.sendMessage(joinInfo.mm())
 

--- a/worlds/src/main/kotlin/gg/airbrush/worlds/listener/GlobalEventListeners.kt
+++ b/worlds/src/main/kotlin/gg/airbrush/worlds/listener/GlobalEventListeners.kt
@@ -29,11 +29,11 @@ class GlobalEventListeners {
         // TODO: Allow user to define spawn point in worlds.toml
         val player = event.player
         player.teleport(Pos(0.0, 6.0, 0.0))
+        player.inventory.clear()
 
         // Prevents creative carrying over from previous worlds
         if (player.gameMode !== GameMode.SURVIVAL) {
             player.gameMode = GameMode.SURVIVAL
-            player.isAllowFlying = true
         }
     }
 }


### PR DESCRIPTION
wipes inventory when transferring worlds