### PR TITLE
Fix deadlock in PluginClassLoader + Debugging

### DIFF
--- a/dev-env/Dockerfile
+++ b/dev-env/Dockerfile
@@ -5,4 +5,6 @@ EXPOSE 25565
 ENV SERVER_PORT=25565
 COPY ./schematics ./schematics
 
+ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
+
 ENTRYPOINT [ "java", "-jar", "airbrush.jar" ]

--- a/dev-env/README.md
+++ b/dev-env/README.md
@@ -49,3 +49,16 @@ Once Airbrush is up and running, you're free to join with the IP of `127.0.0.1:2
 > [!NOTE]
 > When updating a singular plugin, instead of running `./gradlew shadowJar` in the root, you can run it on the particular submodule itself. This way only that particular plugin is updated within the development container, *and* you save some time!
 
+### Debugging Airbrush
+
+It is assumed that you're using IntelliJ IDEA for this. If you're not, you will need to look up instructions for your
+particular IDE.
+
+1 - Open the `Edit Configurations...` menu in the top right of the IDE.
+
+2 - Click the `+` icon in the top left and select `Remote JVM Debug`. Make sure the debugger mode is set to
+`Attach to remote JVM`. The host must be `localhost` and the port must be set to `5005`. When done, click `Apply` and
+then `OK`.
+
+3 - Create a breakpoint, then run the `Remote JVM Debug` configuration. This will attach the debugger to the running
+JVM instance in the docker container. See [Running Airbrush](#running-airbrush) for how to start Airbrush.

--- a/dev-env/docker-compose.yml
+++ b/dev-env/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     restart: always
     ports:
       - "25565:25565"
+      - "5005:5005"
     depends_on:
       - mongo
     volumes:

--- a/server/src/main/kotlin/gg/airbrush/server/plugins/PluginClassLoader.kt
+++ b/server/src/main/kotlin/gg/airbrush/server/plugins/PluginClassLoader.kt
@@ -16,42 +16,86 @@ import cc.ekblad.toml.decode
 import cc.ekblad.toml.tomlMapper
 import gg.airbrush.server.pluginManager
 import net.minestom.server.MinecraftServer
+import org.slf4j.LoggerFactory
 import java.io.File
 import java.net.URLClassLoader
 
 class PluginClassLoader(private val file: File, parent: ClassLoader) : URLClassLoader(arrayOf(file.toURI().toURL()), parent) {
     private var cachedInfo: PluginInfo? = null
+    private val logger = LoggerFactory.getLogger(PluginClassLoader::class.java)
+    private val cachedClasses = HashMap<String, Class<*>>()
 
-    override fun loadClass(name: String, resolve: Boolean): Class<*> {
-        return loadClass0(name, resolve, true)
+//    override fun loadClass(name: String, resolve: Boolean): Class<*> {
+//        println("[${Thread.currentThread().name}] Plugin '${cachedInfo?.name}' is loading class '$name'")
+//        return loadClass0(name, resolve, true)
+//    }
+//
+//    private fun loadClass0(name: String, resolve: Boolean, checkPlugins: Boolean): Class<*> {
+//        if (checkPlugins) {
+//            for (plugin in pluginManager.plugins.values) {
+//                try {
+//                    val clazz = plugin.loader.loadClass0(name, resolve, false)
+//                    val loader = clazz.classLoader
+//
+//                    if (loader is PluginClassLoader) {
+//                        val info = loader.getPluginInfo() ?: return clazz
+//
+//                        if (plugin.info.dependencies.contains(info.id) || info.id == plugin.info.id)
+//                            return clazz
+//
+//                        MinecraftServer.LOGGER.info("Plugin '${plugin.info.id}' loaded class '${clazz.name}' from non-dependency plugin '${info.id}'.")
+//                    }
+//
+//                    return clazz
+//                } catch (_: ClassNotFoundException) {
+//                }
+//            }
+//        }
+//
+//        return super.loadClass(name, resolve)
+//    }
+
+    override fun findClass(name: String): Class<*> {
+        return findClass(name, true)
     }
 
-    private fun loadClass0(name: String, resolve: Boolean, checkPlugins: Boolean): Class<*> {
-        try {
-            return super.loadClass(name, resolve)
-        } catch (_: ClassNotFoundException) {}
+    private fun findClass(name: String, checkPlugins: Boolean): Class<*> {
+        if (cachedClasses.containsKey(name)) {
+            return cachedClasses[name]!!
+        }
 
-        if (checkPlugins)
-            for (plugin in pluginManager.plugins.values) {
-
-                try {
-                    val clazz = plugin.loader.loadClass0(name, resolve, false)
-                    val loader = clazz.classLoader
-
-                    if (loader is PluginClassLoader) {
-                        val info = loader.getPluginInfo() ?: return clazz
-
-                        if (plugin.info.dependencies.contains(info.id) || info.id == plugin.info.id)
-                            return clazz
-
-                        MinecraftServer.LOGGER.info("Plugin '${plugin.info.id}' loaded class '${clazz.name}' from non-dependency plugin '${info.id}'.")
-                    }
-
-                    return clazz
-                } catch (_: ClassNotFoundException) { }
+        if (checkPlugins) {
+            if (cachedParentClasses.containsKey(name)) {
+                return cachedParentClasses[name]!!
             }
 
-        throw ClassNotFoundException(name)
+            for (plugin in pluginManager.plugins.values) {
+                try {
+                    val clazz = plugin.loader.findClass(name, false)
+                    val classLoader = clazz.classLoader
+
+                    if (classLoader is PluginClassLoader) {
+                        classLoader.cachedInfo?.let { info ->
+                            if (!plugin.info.dependencies.contains(info.id) && info.id != plugin.info.id) {
+                                logger.warn("Plugin '${plugin.info.id}' loaded class '${clazz.name}' from non-dependency plugin '${info.id}'.")
+                            }
+                        }
+                    }
+
+                    cachedClasses[name] = clazz
+                    return clazz
+                } catch (_: ClassNotFoundException) {
+                }
+            }
+        }
+
+        val clazz = super.findClass(name)
+        if (clazz != null) {
+            cachedParentClasses[name] = clazz
+//            cachedClasses[name] = clazz
+        }
+
+        return clazz
     }
 
     fun getPluginInfo(): PluginInfo? {
@@ -73,5 +117,9 @@ class PluginClassLoader(private val file: File, parent: ClassLoader) : URLClassL
 
         cachedInfo = info
         return info
+    }
+
+    private companion object {
+        val cachedParentClasses = HashMap<String, Class<*>>()
     }
 }


### PR DESCRIPTION
This PR fixes the deadlock that occurred when two threads tried to access the same plugin class loader. 

From commit message:
```
The PluginClassLoader overwrote the loadClass() method instead of
findClass(). This bypassed the JVM's default locking mechanism for
class loaders, allows two threads accessing the same class loader to
block each other.
```

See the following resources for more information:
- https://stackoverflow.com/questions/18640996/java-deadlock-in-classloaders
- https://docs.oracle.com/javase/7/docs/technotes/guides/lang/cl-mt.html

Also, JVM properties were added to allow attaching a remote debugger to Airbrush when running through Docker. Instructions are in dev-env/README.md.